### PR TITLE
Break out of loop if cell not in UITableView view hierachy

### DIFF
--- a/BMXSwipableCell/BMXSwipableCell.m
+++ b/BMXSwipableCell/BMXSwipableCell.m
@@ -111,12 +111,17 @@ static const CGFloat kDefaultUITableViewDeleteControlWidth = 47;
     // search for the parent table view
     //
     UIView *view = self.superview;
-    while (! [view isKindOfClass: [UITableView class]]) {
+    while (view && (! [view isKindOfClass: [UITableView class]])) {
         view = view.superview;
     }
-    
-    NSAssert([view isKindOfClass: [UITableView class]], @"UITableView not found");
-    
+
+#ifdef BMX_SWIPABLE_CELL_LOG_ENABLED
+    if (! view) {
+        // cell is not contained in a UITableView view hierarchy
+        NSLog(@"UITableView not found");
+    }
+#endif
+
     _tableView = (UITableView*)view;
 }
 


### PR DESCRIPTION
This fixes an issue when the cell is not contained in a `UITableView` view hierarchy or does not have any superview at all. I observed this behavior on both iOS 7.0 and iOS 7.1 during scrolling. Perhaps the cell reuse mechanism within `UITableView` causes the cells to have no superview when the `UITableView` puts them in the reuse pool.

In this case, the implementation of `-[BMXSwipableCell didMoveToSuperview]` sets `_tableView` to `nil`. Please have a look if this does not cause any unwanted side effects.
